### PR TITLE
fix error during 1st band select before run

### DIFF
--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -64,6 +64,7 @@ class analyser:
         self.scale = 174
         self.scanMemory = 50
         self.scan3D = False
+        self.rbw = None
 
     @property
     def frequencies(self):
@@ -212,7 +213,7 @@ class analyser:
         self.serialSend(rbw_command)
 
     def setPoints(self):
-        if ui.points_auto.isChecked():
+        if ui.points_auto.isChecked() and self.rbw is not None :
             points = int((ui.span_freq.value()*1000)/(float(self.rbw)/2))  # values in kHz
             # future - (self.rbw)/3) for best power accuracy: allow this to be set in 'preferences'
             logging.debug(f'points = {points}')


### PR DESCRIPTION
When selecting a new band before the 1st run I get this error and only the start frequency was changed:

```python
Traceback (most recent call last):
  File "/home/horo/projects/tinySA/QtTinySA/QtTinySA.py", line 563, in band_changed
    start_freq_changed(False)
  File "/home/horo/projects/tinySA/QtTinySA/QtTinySA.py", line 527, in start_freq_changed
    tinySA.setPoints()
  File "/home/horo/projects/tinySA/QtTinySA/QtTinySA.py", line 217, in setPoints
    points = int((ui.span_freq.value()*1000)/(float(self.rbw)/2))  # values in kHz
                                                    ^^^^^^^^
AttributeError: 'analyser' object has no attribute 'rbw'
```