### PR TITLE
Fix 3D spectrum error on Windows 10

### DIFF
--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -1360,8 +1360,7 @@ if platform.system() == "Windows":
     from PyQt5.QtCore import QCoreApplication
     from PyQt5.QtCore import Qt
     # force Qt to use OpenGL rather than DirectX for Windows OS
-    QCoreApplication.setAttribute(Qt.AA_UseOpenGLES)
-    #QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+    QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
 
 app = QtWidgets.QApplication([])  # create QApplication for the GUI
 app.setApplicationName('QtTinySA')

--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -57,6 +57,11 @@ import pyqtgraph.opengl as pyqtgl
 if system() == "Linux":
     os.environ['XDG_CONFIG_DIRS'] = '/etc:/usr/local/etc'
     os.environ['XDG_DATA_DIRS'] = '/usr/share:/usr/local/share'
+# Fix 3D Spectrum Rendering not working on Windows using DirectX by default
+elif system() == "Windows":
+    # force Qt to use OpenGL rather than DirectX for Windows OS
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_UseDesktopOpenGL)
+
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 threadpool = QtCore.QThreadPool()
@@ -1353,14 +1358,6 @@ def colourID(shade):  # using the QSQLRelation directly doesn't work for colour.
 # Instantiate classes
 
 tinySA = analyser()
-
-# Fix 3D Spectrum Rendering not working on Windows using DirectX by default
-import platform
-if platform.system() == "Windows":
-    from PyQt5.QtCore import QCoreApplication
-    from PyQt5.QtCore import Qt
-    # force Qt to use OpenGL rather than DirectX for Windows OS
-    QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
 
 app = QtWidgets.QApplication([])  # create QApplication for the GUI
 app.setApplicationName('QtTinySA')

--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -1360,7 +1360,8 @@ if platform.system() == "Windows":
     from PyQt5.QtCore import QCoreApplication
     from PyQt5.QtCore import Qt
     # force Qt to use OpenGL rather than DirectX for Windows OS
-    QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+    QCoreApplication.setAttribute(Qt.AA_UseOpenGLES)
+    #QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
 
 app = QtWidgets.QApplication([])  # create QApplication for the GUI
 app.setApplicationName('QtTinySA')

--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -1355,7 +1355,7 @@ def colourID(shade):  # using the QSQLRelation directly doesn't work for colour.
 tinySA = analyser()
 # mod
 import platform
-if platform.system == "Windows":
+if platform.system() == "Windows":
     from PyQt5.QtCore import QCoreApplication
     from PyQt5.QtCore import Qt
     # force Qt to use OpenGL rather than DirectX for Windows OS

--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -1353,7 +1353,14 @@ def colourID(shade):  # using the QSQLRelation directly doesn't work for colour.
 # Instantiate classes
 
 tinySA = analyser()
-
+# mod
+import platform
+if platform.system == "Windows":
+    from PyQt5.QtCore import QCoreApplication
+    from PyQt5.QtCore import Qt
+    # force Qt to use OpenGL rather than DirectX for Windows OS
+    QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+# end mod
 app = QtWidgets.QApplication([])  # create QApplication for the GUI
 app.setApplicationName('QtTinySA')
 app.setApplicationVersion(' v0.11.8')

--- a/QtTinySA.py
+++ b/QtTinySA.py
@@ -1353,14 +1353,15 @@ def colourID(shade):  # using the QSQLRelation directly doesn't work for colour.
 # Instantiate classes
 
 tinySA = analyser()
-# mod
+
+# Fix 3D Spectrum Rendering not working on Windows using DirectX by default
 import platform
 if platform.system() == "Windows":
     from PyQt5.QtCore import QCoreApplication
     from PyQt5.QtCore import Qt
     # force Qt to use OpenGL rather than DirectX for Windows OS
     QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
-# end mod
+
 app = QtWidgets.QApplication([])  # create QApplication for the GUI
 app.setApplicationName('QtTinySA')
 app.setApplicationVersion(' v0.11.8')


### PR DESCRIPTION
As the issue I found here: https://github.com/g4ixt/QtTinySA/issues/74

Here's my solution of fixing this issue by forcing to use OpenGL on Windows rather than DirectX to render 3D spectrum.

Tested on Windows 10 x86_64 and the 3D spectrum looks fine.

![image](https://github.com/user-attachments/assets/4b94c97b-8ddb-4509-9dc9-fd48a07581b6)
