### PR TITLE
Custom CSV exporters for Shure Wireless Workbench and Sennheiser WSM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 dist/
 firmware_possible_issue.txt
 /executables
+/venv

--- a/src/QtTinyExporters.py
+++ b/src/QtTinyExporters.py
@@ -1,0 +1,208 @@
+import csv
+import itertools
+
+import numpy as np
+
+from PyQt5.QtWidgets import QMessageBox
+
+from pyqtgraph import ErrorBarItem, PlotItem
+from pyqtgraph.exporters import CSVExporter
+from pyqtgraph.parametertree import Parameter
+
+
+class QtTinySAExportException(Exception):
+    """Custom exception for custom pyqtgraph exporters."""
+
+
+class WWBExporter(CSVExporter):
+    Name = "CSV for WWB (Shure)"
+
+    def __init__(self, item):
+        CSVExporter.__init__(self, item)
+        self.params = Parameter.create(name='params', type='group', children=[
+            {'name': 'trace', 'title': 'Export trace', 'type': 'list',
+             'value': 1, 'limits': [1, 2, 3, 4]}
+        ])
+        self.index_counter = itertools.count(start=0)
+        self.header = []
+        self.data = []
+
+    def _exportPlotDataItem(self, plotDataItem) -> None:
+        if hasattr(plotDataItem, 'getOriginalDataset'):
+            # try to access unmapped, unprocessed data
+            cd = plotDataItem.getOriginalDataset()
+        else:
+            # fall back to earlier access method
+            cd = plotDataItem.getData()
+        if cd[0] is None:
+            # no data found, break out...
+            return None
+        self.data.append(cd)
+        return None
+
+    def export(self, fileName=None):
+        if not isinstance(self.item, PlotItem):
+            raise TypeError("Must have a PlotItem selected for CSV export.")
+        if fileName is None:
+            self.fileSaveDialog(filter=["*.csv", "*.tsv"])
+            return
+        for item in self.item.items:
+            if isinstance(item, ErrorBarItem):
+                self._exportErrorBarItem(item)
+            elif hasattr(item, 'implements') and item.implements('plotData'):
+                self._exportPlotDataItem(item)
+        try:
+            # we want to flatten the nested arrays of data into columns
+            columns = [column for dataset in self.data for column in dataset]
+            if len(columns) == 0:
+                raise QtTinySAExportException(
+                    'No column data to export / empty graph!')
+            if len(columns) <= self.params['trace'] * 2:
+                raise QtTinySAExportException(
+                    "Missing column data for selected trace - can't export!")
+            row_x = 0
+            row_y = 1
+            if self.params['trace'] == 1:
+                row_x = 0
+                row_y = 1
+            elif self.params['trace'] == 2:
+                row_x = 2
+                row_y = 3
+            elif self.params['trace'] == 3:
+                row_x = 4
+                row_y = 5
+            elif self.params['trace'] == 4:
+                row_x = 6
+                row_y = 7
+            with open(fileName, 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.writer(csvfile, delimiter=',',
+                                    quoting=csv.QUOTE_MINIMAL)
+                for row in itertools.zip_longest(*columns, fillvalue=""):
+                    if isinstance(row[row_x], str):
+                        x = row[row_x]
+                    else:
+                        x = np.format_float_positional(row[row_x] / 1000000,
+                                                       precision=3,
+                                                       unique=True,
+                                                       min_digits=3,
+                                                       fractional=True)
+                    if isinstance(row[row_y], str):
+                        y = row[row_y]
+                    else:
+                        y = np.format_float_positional(row[row_y],
+                                                       precision=4,
+                                                       unique=True,
+                                                       min_digits=4,
+                                                       fractional=True)
+                    row_to_write = [x, y]
+                    writer.writerow(row_to_write)
+        except QtTinySAExportException as e:
+            error_dialog = QMessageBox()
+            error_dialog.setIcon(QMessageBox.Icon.Critical)
+            error_dialog.setText(str(e))
+            error_dialog.setWindowTitle('Error')
+            error_dialog.exec()
+        self.header.clear()
+        self.data.clear()
+
+
+class WSMExporter(CSVExporter):
+    Name = "CSV for WSM (Sennheiser)"
+
+    def __init__(self, item):
+        CSVExporter.__init__(self, item)
+        self.params = Parameter.create(name='params', type='group', children=[
+            {'name': 'trace', 'title': 'Export trace', 'type': 'list',
+             'value': 1, 'limits': [1, 2, 3, 4]}
+        ])
+        self.index_counter = itertools.count(start=0)
+        self.header = []
+        self.data = []
+
+    def _exportPlotDataItem(self, plotDataItem) -> None:
+        if hasattr(plotDataItem, 'getOriginalDataset'):
+            # try to access unmapped, unprocessed data
+            cd = plotDataItem.getOriginalDataset()
+        else:
+            # fall back to earlier access method
+            cd = plotDataItem.getData()
+        if cd[0] is None:
+            # no data found, break out...
+            return None
+        self.data.append(cd)
+        return None
+
+    def export(self, fileName=None):
+        if not isinstance(self.item, PlotItem):
+            raise TypeError("Must have a PlotItem selected for CSV export.")
+        if fileName is None:
+            self.fileSaveDialog(filter=["*.csv", "*.tsv"])
+            return
+        for item in self.item.items:
+            if isinstance(item, ErrorBarItem):
+                self._exportErrorBarItem(item)
+            elif hasattr(item, 'implements') and item.implements('plotData'):
+                self._exportPlotDataItem(item)
+        try:
+            # we want to flatten the nested arrays of data into columns
+            columns = [column for dataset in self.data for column in dataset]
+            if len(columns) == 0:
+                raise QtTinySAExportException(
+                    "No column data to export / empty graph!")
+            if len(columns) <= self.params['trace'] * 2:
+                raise QtTinySAExportException(
+                    "Missing column data for selected trace - can't export!")
+            row_x = 0
+            row_y = 1
+            if self.params['trace'] == 1:
+                row_x = 0
+                row_y = 1
+            elif self.params['trace'] == 2:
+                row_x = 2
+                row_y = 3
+            elif self.params['trace'] == 3:
+                row_x = 4
+                row_y = 5
+            elif self.params['trace'] == 4:
+                row_x = 6
+                row_y = 7
+            self.header = [["Receiver", ''],
+                        ["Date/Time", ''],
+                        ["RFUnit", "dBm"],
+                        ["Owner", ''],
+                        ["ScanCity", ''],
+                        ["ScanComment", ''],
+                        ["ScanCountry", ''],
+                        ["ScanDescription", ''],
+                        ["ScanInteriorExterior", ''],
+                        ["ScanLatitude", ''],
+                        ["ScanLongitude", ''],
+                        ["ScanName", ''],
+                        ["ScanPostalCode", ''],
+                        ["Frequency Range [kHz]",
+                            f"{int(columns[row_x][0] / 1000)}",
+                            f"{int(columns[row_x][-1] / 1000)}",
+                            f"{len(columns[row_x])}"],
+                        ["Frequency", "RF level (%)", "RF level"]]
+            with open(fileName, 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.writer(csvfile, delimiter=';', quoting=csv.QUOTE_MINIMAL)
+                writer.writerows(self.header)
+                for row in itertools.zip_longest(*columns, fillvalue=""):
+                    if isinstance(row[row_x], str):
+                        x = row[row_x]
+                    else:
+                        x = int(row[row_x] / 1000)
+                    if isinstance(row[row_y], str):
+                        y = row[row_y]
+                    else:
+                        y = np.format_float_positional(row[row_y], precision=5)
+                    row_to_write = [x, '', y]
+                    writer.writerow(row_to_write)
+        except QtTinySAExportException as e:
+            error_dialog = QMessageBox()
+            error_dialog.setIcon(QMessageBox.Icon.Critical)
+            error_dialog.setText(str(e))
+            error_dialog.setWindowTitle('Error')
+            error_dialog.exec()
+        self.header.clear()
+        self.data.clear()

--- a/src/QtTinyExporters.py
+++ b/src/QtTinyExporters.py
@@ -15,19 +15,30 @@ class QtTinySAExportException(Exception):
 
 
 class WWBExporter(CSVExporter):
+    """Shure Wireless Workbench CSV exporter class."""
+
     Name = "CSV for WWB (Shure)"
 
     def __init__(self, item):
+        """Class initialisation."""
+        # init superclass
         CSVExporter.__init__(self, item)
+        # define parameters:
+        # parameter 'trace' lets you select which trace (1-4) should be exported
+        # as WWB can only read one trace over frequencies at a time
         self.params = Parameter.create(name='params', type='group', children=[
             {'name': 'trace', 'title': 'Export trace', 'type': 'list',
              'value': 1, 'limits': [1, 2, 3, 4]}
         ])
+        # class variables:
         self.index_counter = itertools.count(start=0)
+        # class variable for CSV header row(s)
         self.header = []
+        # class variable holding the data points
         self.data = []
 
     def _exportPlotDataItem(self, plotDataItem) -> None:
+        """Export selected trace data points to class data variable."""
         if hasattr(plotDataItem, 'getOriginalDataset'):
             # try to access unmapped, unprocessed data
             cd = plotDataItem.getOriginalDataset()
@@ -41,11 +52,14 @@ class WWBExporter(CSVExporter):
         return None
 
     def export(self, fileName=None):
+        """Export handler to prepare and export the data to a CSV file."""
         if not isinstance(self.item, PlotItem):
             raise TypeError("Must have a PlotItem selected for CSV export.")
+        # show file dialog to select file save location
         if fileName is None:
             self.fileSaveDialog(filter=["*.csv", "*.tsv"])
             return
+        # handle error bar items and plot data
         for item in self.item.items:
             if isinstance(item, ErrorBarItem):
                 self._exportErrorBarItem(item)
@@ -54,12 +68,15 @@ class WWBExporter(CSVExporter):
         try:
             # we want to flatten the nested arrays of data into columns
             columns = [column for dataset in self.data for column in dataset]
+            # error handling
             if len(columns) == 0:
                 raise QtTinySAExportException(
                     'No column data to export / empty graph!')
             if len(columns) <= self.params['trace'] * 2:
                 raise QtTinySAExportException(
                     "Missing column data for selected trace - can't export!")
+            # select x and y based on choosen trace
+            # could be done more elegant, but this works ;-)
             row_x = 0
             row_y = 1
             if self.params['trace'] == 1:
@@ -74,52 +91,75 @@ class WWBExporter(CSVExporter):
             elif self.params['trace'] == 4:
                 row_x = 6
                 row_y = 7
+            # write CSV file
             with open(fileName, 'w', newline='', encoding='utf-8') as csvfile:
+                # set CSV flavor
                 writer = csv.writer(csvfile, delimiter=',',
                                     quoting=csv.QUOTE_MINIMAL)
+                # iterate thru data and write row by row
                 for row in itertools.zip_longest(*columns, fillvalue=""):
                     if isinstance(row[row_x], str):
+                        # data is string -> do nothing
                         x = row[row_x]
                     else:
-                        x = np.format_float_positional(row[row_x] / 1000000,
+                        # data is number (?) -> convert to float and set precision
+                        # convert frequencies to MHz with precision of 0.000
+                        x = np.format_float_positional(int(row[row_x]) / 1000000,
                                                        precision=3,
                                                        unique=True,
                                                        min_digits=3,
                                                        fractional=True)
                     if isinstance(row[row_y], str):
+                        # data is string -> do nothing
                         y = row[row_y]
                     else:
-                        y = np.format_float_positional(row[row_y],
+                        # data is number (?) -> convert to float and set precision
+                        # convert level dB values to floating with 0.0000
+                        y = np.format_float_positional(int(row[row_y]),
                                                        precision=4,
                                                        unique=True,
                                                        min_digits=4,
                                                        fractional=True)
+                    # prepare row to write
                     row_to_write = [x, y]
+                    # write row to file
                     writer.writerow(row_to_write)
         except QtTinySAExportException as e:
+            # show error dialog box in window with error description
             error_dialog = QMessageBox()
             error_dialog.setIcon(QMessageBox.Icon.Critical)
             error_dialog.setText(str(e))
             error_dialog.setWindowTitle('Error')
             error_dialog.exec()
+        # garbage collection, cleaning up!
         self.header.clear()
         self.data.clear()
 
 
 class WSMExporter(CSVExporter):
+    """Sennheiser WSM CSV exporter class."""
     Name = "CSV for WSM (Sennheiser)"
 
     def __init__(self, item):
+        """Class initialisation."""
+        # init superclass
         CSVExporter.__init__(self, item)
+        # define parameters:
+        # parameter 'trace' lets you select which trace (1-4) should be exported
+        # as WWB can only read one trace over frequencies at a time
         self.params = Parameter.create(name='params', type='group', children=[
             {'name': 'trace', 'title': 'Export trace', 'type': 'list',
              'value': 1, 'limits': [1, 2, 3, 4]}
         ])
+        # class variables:
         self.index_counter = itertools.count(start=0)
+        # class variable for CSV header row(s)
         self.header = []
+        # class variable holding the data points
         self.data = []
 
     def _exportPlotDataItem(self, plotDataItem) -> None:
+        """Export selected trace data points to class data variable."""
         if hasattr(plotDataItem, 'getOriginalDataset'):
             # try to access unmapped, unprocessed data
             cd = plotDataItem.getOriginalDataset()
@@ -133,11 +173,14 @@ class WSMExporter(CSVExporter):
         return None
 
     def export(self, fileName=None):
+        """Export handler to prepare and export the data to a CSV file."""
         if not isinstance(self.item, PlotItem):
             raise TypeError("Must have a PlotItem selected for CSV export.")
+        # show file dialog to select file save location
         if fileName is None:
             self.fileSaveDialog(filter=["*.csv", "*.tsv"])
             return
+        # handle error bar items and plot data
         for item in self.item.items:
             if isinstance(item, ErrorBarItem):
                 self._exportErrorBarItem(item)
@@ -146,12 +189,15 @@ class WSMExporter(CSVExporter):
         try:
             # we want to flatten the nested arrays of data into columns
             columns = [column for dataset in self.data for column in dataset]
+            # error handling
             if len(columns) == 0:
                 raise QtTinySAExportException(
                     "No column data to export / empty graph!")
             if len(columns) <= self.params['trace'] * 2:
                 raise QtTinySAExportException(
                     "Missing column data for selected trace - can't export!")
+            # select x and y based on choosen trace
+            # could be done more elegant, but this works ;-)
             row_x = 0
             row_y = 1
             if self.params['trace'] == 1:
@@ -184,25 +230,36 @@ class WSMExporter(CSVExporter):
                             f"{int(columns[row_x][-1] / 1000)}",
                             f"{len(columns[row_x])}"],
                         ["Frequency", "RF level (%)", "RF level"]]
+            # write CSV file
             with open(fileName, 'w', newline='', encoding='utf-8') as csvfile:
+                # set CSV flavor to use ; instead of , (required by WSM)
                 writer = csv.writer(csvfile, delimiter=';', quoting=csv.QUOTE_MINIMAL)
                 writer.writerows(self.header)
+                # iterate thru data and write row by row
                 for row in itertools.zip_longest(*columns, fillvalue=""):
                     if isinstance(row[row_x], str):
+                        # data is string -> do nothing
                         x = row[row_x]
                     else:
-                        x = int(row[row_x] / 1000)
+                        # convert frequency to kHz
+                        x = int(row[row_x]) / 1000
                     if isinstance(row[row_y], str):
+                        # data is string -> do nothing
                         y = row[row_y]
                     else:
-                        y = np.format_float_positional(row[row_y], precision=5)
+                        # convert level to float with precision 0.00000
+                        y = np.format_float_positional(int(row[row_y]), precision=5)
+                     # prepare row to write
                     row_to_write = [x, '', y]
+                    # write row to file
                     writer.writerow(row_to_write)
         except QtTinySAExportException as e:
+            # show error dialog box in window with error description
             error_dialog = QMessageBox()
             error_dialog.setIcon(QMessageBox.Icon.Critical)
             error_dialog.setText(str(e))
             error_dialog.setWindowTitle('Error')
             error_dialog.exec()
+        # garbage collection, cleaning up!
         self.header.clear()
         self.data.clear()

--- a/src/QtTinySA.py
+++ b/src/QtTinySA.py
@@ -41,6 +41,7 @@ from PyQt5.QtSql import QSqlDatabase, QSqlRelation, QSqlRelationalTableModel, QS
 from PyQt5.QtGui import QPixmap, QIcon
 from datetime import datetime
 import pyqtgraph
+from QtTinyExporters import WWBExporter, WSMExporter
 import QtTinySpectrum  # the main GUI
 import QtTSApreferences  # the preferences GUI
 import QtTSAfilebrowse  # the tinySA SD card browser GUI
@@ -69,6 +70,11 @@ basedir = os.path.dirname(__file__)
 # pyqtgraph pens
 red_dash = pyqtgraph.mkPen(color='r', width=0.5, style=QtCore.Qt.DashLine)
 blue_dash = pyqtgraph.mkPen(color='b', width=0.5,  style=QtCore.Qt.DashLine)
+
+# pyqtgraph custom exporters
+WWBExporter.register()
+WSMExporter.register()
+
 
 
 ###############################################################################

--- a/src/QtTinySA.spec
+++ b/src/QtTinySA.spec
@@ -1,89 +1,51 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-import sys
 
-block_cipher = None
+a = Analysis(
+    ['QtTinySA.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
 
-common = {
-    'pathex': [],
-    'binaries': [],
-    'datas': [('QtTSAprefs.db', '.')],
-    'hiddenimports': [],
-    'hookspath': [],
-    'hooksconfig': {},
-    'runtime_hooks': [],
-    'excludes': ['pandas', 'setuptools', 'tk', 'wheel', 'zipp', 'pyyaml', 'packaging', 'altgraph', 'mkl', 'fortran', 'matlab'],
-    'win_no_prefer_redirects': False,
-    'win_private_assemblies': False,
-    'cipher': block_cipher,
-    'noarchive': False,
-}
-
-a = Analysis( ['QtTinySA.py'], **common)
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
-
-if sys.platform != 'darwin':
-    exe = EXE(
-        pyz,
-        a.scripts,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        [],
-        name='QtTinySA',
-        debug=False,
-        bootloader_ignore_signals=False,
-        strip=False,
-        upx=True,
-        upx_exclude=[],
-        runtime_tmpdir=None,
-        console=True,
-        disable_windowed_traceback=False,
-        argv_emulation=False,
-        target_arch=None,
-        codesign_identity=None,
-        entitlements_file=None,
-        icon='tinySA.ico'
-    )
-    
-# macOS
-else:
-    exe = EXE(
-        pyz,
-        a.scripts,
-        [],
-        name='QtTinySA',
-        debug=False,
-        bootloader_ignore_signals=False,
-        strip=False,
-        upx=True,
-        upx_exclude=[],
-        runtime_tmpdir=None,
-        console=True,
-        disable_windowed_traceback=False,
-        argv_emulation=False,
-        target_arch=None,
-        codesign_identity=None,
-        entitlements_file=None,
-        exclude_binaries=True,
-        icon='tinySA.icns'
-    )
-
-    app = BUNDLE(
-        exe,
-        a.binaries,
-        a.datas,
-        strip=False,
-        upx=True,
-        upx_exclude=[],
-        name='QtTinySA.app',
-        icon='tinySA.icns',
-        bundle_identifier=None,
-        info_plist={
-            'CFBundleName': 'QtTinySA',
-            'CFBundleDisplayName': 'QtTinySA',
-            'NSHumanReadableCopyright': 'Copyright © 2025 QtTinySA',
-            'LSUIElement': False,
-            'LSBackgroundOnly': False,
-        },
-    )
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='QtTinySA',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['tinySA.icns'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='QtTinySA',
+)
+app = BUNDLE(
+    coll,
+    name='QtTinySA.app',
+    icon='tinySA.icns',
+    bundle_identifier=None,
+)


### PR DESCRIPTION
As I primarily use QtTinySA to scan frequencies in the wireless audio bands I added custom exporters to write CSV flavours for Shure's Wireless Workbench and Sennheiser's WSM software.
These tools manage wireless microphones and wireless inear monitor systems and can import scan data from CSV.

Unfortunately the CSV exported from pyqtgraph can't be read directly by these programs.

The added exporters write in the expected format and allow the user to select the trace number to be written to the exported file (traces 1-4).

If something goes wrong exporting a error dialog is show to inform the user.

As I'm working on macOS the .spec file has been adapted by pyinstaller.

I (re)opened a pull request after applying my changes to the new main branch from 25-05-22 and reapplying my changes and extensions. I tried to document my Exporters module as much as possible - hope it explains what it does.