### PR TITLE
Add headless sweep and spectrum plotting CLIs

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,8 @@
 numpy
+pandas
+matplotlib
 Pillow
 platformdirs
 pyserial
 pyqtgraph
 pyside6
-

--- a/src/spectrum_plotter.py
+++ b/src/spectrum_plotter.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Plot tinySA spectrum CSV files and report the strongest peaks."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "qttinysa-matplotlib"))
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+DEFAULT_INPUT = Path("sweep_files/sweep.csv")
+DEFAULT_SAVE_DIR = Path("sweep_files")
+
+
+def read_spectrum_csv(path: Path) -> list[dict[str, object]]:
+    """Read CLI CSVs, QtTinySA trace-pair CSVs, or headerless sweep CSVs."""
+    df = pd.read_csv(path)
+    traces: list[dict[str, object]] = []
+
+    if {"frequency_hz", "dbm"}.issubset(df.columns):
+        trace = df[["frequency_hz", "dbm"]].apply(pd.to_numeric, errors="coerce").dropna()
+        return [{
+            "label": path.stem,
+            "freq_hz": trace["frequency_hz"],
+            "dbm": trace["dbm"],
+        }]
+
+    x_columns = [column for column in df.columns if str(column).endswith("_x")]
+    for x_column in x_columns:
+        stem = str(x_column)[:-2]
+        y_column = f"{stem}_y"
+        if y_column not in df.columns:
+            continue
+
+        trace = df[[x_column, y_column]].apply(pd.to_numeric, errors="coerce").dropna()
+        traces.append({
+            "label": f"{path.stem} trace {stem}",
+            "freq_hz": trace[x_column],
+            "dbm": trace[y_column],
+        })
+
+    if traces:
+        return traces
+
+    # Fallback for QtTinySA save-sweep CSVs: no header, frequency in column 0,
+    # one or more reading columns after it.
+    df = pd.read_csv(path, header=None).apply(pd.to_numeric, errors="coerce")
+    if df.shape[1] < 2:
+        raise ValueError(f"{path} does not look like spectrum data")
+
+    for column in df.columns[1:]:
+        trace = df[[0, column]].dropna()
+        traces.append({
+            "label": f"{path.stem} sweep {column}",
+            "freq_hz": trace[0],
+            "dbm": trace[column],
+        })
+    return traces
+
+
+def load_traces(paths: Iterable[Path]) -> list[dict[str, object]]:
+    traces: list[dict[str, object]] = []
+    for path in paths:
+        traces.extend(read_spectrum_csv(path))
+    if not traces:
+        raise ValueError("no traces found")
+    return traces
+
+
+def local_peak_indexes(values: pd.Series) -> pd.Index:
+    previous_values = values.shift(1)
+    next_values = values.shift(-1)
+    is_peak = values.ge(previous_values.fillna(float("-inf"))) & values.ge(next_values.fillna(float("-inf")))
+    return values[is_peak].index
+
+
+def strongest_peaks(traces: list[dict[str, object]], count: int = 5) -> pd.DataFrame:
+    rows = []
+    for trace in traces:
+        freq_hz = trace["freq_hz"]
+        dbm = trace["dbm"]
+        assert isinstance(freq_hz, pd.Series)
+        assert isinstance(dbm, pd.Series)
+        median_dbm = dbm.median()
+
+        peak_indexes = local_peak_indexes(dbm)
+        peak_data = pd.DataFrame({
+            "frequency_hz": freq_hz.loc[peak_indexes],
+            "dbm": dbm.loc[peak_indexes],
+        })
+        if len(peak_data) < count:
+            peak_data = pd.DataFrame({"frequency_hz": freq_hz, "dbm": dbm})
+
+        peak_data = peak_data.sort_values("dbm", ascending=False).head(count)
+        for rank, (_index, row) in enumerate(peak_data.iterrows(), start=1):
+            rows.append({
+                "trace": trace["label"],
+                "maximum_rank": rank,
+                "frequency_hz": int(round(row["frequency_hz"])),
+                "frequency_mhz": row["frequency_hz"] / 1e6,
+                "dbm": row["dbm"],
+                "above_median_db": row["dbm"] - median_dbm,
+            })
+    return pd.DataFrame(rows)
+
+
+def trace_summary(traces: list[dict[str, object]]) -> pd.DataFrame:
+    rows = []
+    for trace in traces:
+        freq_hz = trace["freq_hz"]
+        dbm = trace["dbm"]
+        assert isinstance(freq_hz, pd.Series)
+        assert isinstance(dbm, pd.Series)
+        rows.append({
+            "trace": trace["label"],
+            "points": len(dbm),
+            "start_MHz": freq_hz.min() / 1e6,
+            "stop_MHz": freq_hz.max() / 1e6,
+            "min_dBm": dbm.min(),
+            "median_dBm": dbm.median(),
+            "mean_dBm": dbm.mean(),
+            "max_dBm": dbm.max(),
+            "dynamic_range_dB": dbm.max() - dbm.min(),
+        })
+    return pd.DataFrame(rows)
+
+
+def console_peak_table(peaks: pd.DataFrame) -> pd.DataFrame:
+    return peaks[["trace", "maximum_rank", "frequency_mhz", "dbm", "above_median_db"]].rename(columns={
+        "maximum_rank": "top_maximum",
+        "frequency_mhz": "frequency_MHz",
+        "dbm": "dBm",
+        "above_median_db": "above_median_dB",
+    })
+
+
+def print_trace_summary(summary: pd.DataFrame) -> None:
+    print("Trace summary")
+    print(summary.to_string(index=False, formatters={
+        "start_MHz": "{:.6f}".format,
+        "stop_MHz": "{:.6f}".format,
+        "min_dBm": "{:.2f}".format,
+        "median_dBm": "{:.2f}".format,
+        "mean_dBm": "{:.2f}".format,
+        "max_dBm": "{:.2f}".format,
+        "dynamic_range_dB": "{:.2f}".format,
+    }))
+
+
+def plot_traces(traces: list[dict[str, object]], title: str) -> tuple[plt.Figure, plt.Axes]:
+    fig, ax = plt.subplots(figsize=(12, 6))
+    for trace in traces:
+        freq_hz = trace["freq_hz"]
+        dbm = trace["dbm"]
+        assert isinstance(freq_hz, pd.Series)
+        assert isinstance(dbm, pd.Series)
+        ax.plot(freq_hz / 1e6, dbm, linewidth=1.4, label=str(trace["label"]))
+
+    ax.set_title(title)
+    ax.set_xlabel("Frequency (MHz)")
+    ax.set_ylabel("Amplitude (dBm)")
+    ax.grid(True, alpha=0.35)
+    ax.legend()
+    fig.tight_layout()
+    return fig, ax
+
+
+def save_outputs(fig: plt.Figure, peaks: pd.DataFrame, save_dir: Path, stem: str) -> tuple[Path, Path]:
+    save_dir.mkdir(parents=True, exist_ok=True)
+    graph_path = save_dir / f"{stem}_spectrum.png"
+    peaks_path = save_dir / f"{stem}_peaks.csv"
+    fig.savefig(graph_path, dpi=150)
+    peaks.to_csv(peaks_path, index=False)
+    return graph_path, peaks_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Plot tinySA spectrum CSV data and print the 5 strongest peaks per trace."
+    )
+    parser.add_argument(
+        "csv_files",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_INPUT],
+        help=f"CSV file(s) to plot (default: {DEFAULT_INPUT})",
+    )
+    parser.add_argument("--peaks", type=int, default=5, help="number of peaks per trace (default: 5)")
+    parser.add_argument("--save", action="store_true", help="save graph and peak CSV to sweep_files")
+    parser.add_argument("--save-dir", type=Path, default=DEFAULT_SAVE_DIR, help="save directory (default: sweep_files)")
+    parser.add_argument("--no-show", action="store_true", help="do not open an interactive plot window")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        traces = load_traces(args.csv_files)
+        summary = trace_summary(traces)
+        peaks = strongest_peaks(traces, args.peaks)
+        title = ", ".join(path.name for path in args.csv_files)
+        fig, _ax = plot_traces(traces, title)
+
+        print_trace_summary(summary)
+        print()
+        print(f"Top {args.peaks} maxima per trace")
+        print(console_peak_table(peaks).to_string(index=False, formatters={
+            "frequency_MHz": "{:.6f}".format,
+            "dBm": "{:.2f}".format,
+            "above_median_dB": "{:.2f}".format,
+        }))
+
+        if args.save:
+            stem = args.csv_files[0].stem if len(args.csv_files) == 1 else "spectrum"
+            graph_path, peaks_path = save_outputs(fig, peaks, args.save_dir, stem)
+            print(f"\nsaved graph: {graph_path}")
+            print(f"saved peaks: {peaks_path}")
+
+        if not args.no_show:
+            plt.show()
+        else:
+            plt.close(fig)
+        return 0
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tinysa_sweep_cli.py
+++ b/src/tinysa_sweep_cli.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Minimal headless tinySA sweep CLI.
+
+This script intentionally does not import QtTinySA.py because that module starts
+the Qt GUI at import time. It implements the small subset of the serial protocol
+needed for a one-shot sweep and CSV export.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import struct
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    import serial
+    from serial.tools import list_ports
+except ImportError as exc:  # pragma: no cover - exercised only without pyserial
+    raise SystemExit("pyserial is required. Install the project requirements first.") from exc
+
+
+BAUDRATE = 576000
+TINYSA_VID = 0x0483
+TINYSA_PID = 0x5740
+PROMPT = b"ch> "
+DEFAULT_OUTPUT_DIR = Path("sweep_files")
+
+
+class SweepError(RuntimeError):
+    """Raised when the sweep cannot complete cleanly."""
+
+
+def parse_frequency(value: str) -> int:
+    """Parse CLI frequency values such as '2400e6' into integer Hz."""
+    try:
+        frequency = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid frequency value: {value!r}") from exc
+
+    if frequency <= 0:
+        raise argparse.ArgumentTypeError("frequency values must be positive")
+    return int(round(frequency))
+
+
+def parse_points(value: str) -> int:
+    try:
+        points = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid point count: {value!r}") from exc
+
+    if points < 2:
+        raise argparse.ArgumentTypeError("points must be at least 2")
+    return points
+
+
+def center_span_to_start_stop(center_hz: int, span_hz: int) -> tuple[int, int]:
+    if span_hz <= 0:
+        raise ValueError("span must be positive")
+
+    start_hz = int(round(center_hz - span_hz / 2))
+    stop_hz = int(round(center_hz + span_hz / 2))
+    if start_hz < 0:
+        raise ValueError("center/span produces a negative start frequency")
+    if start_hz >= stop_hz:
+        raise ValueError("start frequency must be lower than stop frequency")
+    return start_hz, stop_hz
+
+
+def frequency_axis(start_hz: int, stop_hz: int, points: int) -> list[int]:
+    if points < 2:
+        raise ValueError("points must be at least 2")
+
+    step = (stop_hz - start_hz) / (points - 1)
+    return [int(round(start_hz + index * step)) for index in range(points)]
+
+
+def scale_for_version(version: str) -> int:
+    """Return the GUI-compatible dBm conversion scale for a firmware string."""
+    if version.startswith("tinySA4"):
+        return 174
+    if version.startswith("tinySA"):
+        return 128
+    raise SweepError(f"device did not identify as tinySA: {version!r}")
+
+
+def is_ultra(version: str) -> bool:
+    return version.startswith("tinySA4")
+
+
+def decode_sample(block: bytes, scale: int) -> float:
+    if len(block) != 3:
+        raise SweepError(f"expected 3 data bytes, got {len(block)}")
+
+    _marker, data = struct.unpack("<cH", block)
+    return (data / 32) - scale
+
+
+def write_csv(path: Path, frequencies_hz: Sequence[int], dbm_values: Sequence[float]) -> None:
+    if len(frequencies_hz) != len(dbm_values):
+        raise ValueError("frequency and reading counts differ")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["frequency_hz", "dbm"])
+        for frequency_hz, dbm in zip(frequencies_hz, dbm_values):
+            writer.writerow([frequency_hz, f"{dbm:.2f}"])
+
+
+def default_output_path(output_dir: Path = DEFAULT_OUTPUT_DIR) -> Path:
+    timestamp = time.strftime("%Y-%m-%d-%H%M%S")
+    path = output_dir / f"{timestamp}_sweep.csv"
+    counter = 1
+    while path.exists():
+        path = output_dir / f"{timestamp}_sweep_{counter}.csv"
+        counter += 1
+    return path
+
+
+def find_tinysa_ports() -> list[object]:
+    return [
+        port
+        for port in list_ports.comports()
+        if port.vid == TINYSA_VID and port.pid == TINYSA_PID
+    ]
+
+
+def choose_port(port_override: str | None) -> str:
+    if port_override:
+        return port_override
+
+    ports = find_tinysa_ports()
+    if not ports:
+        raise SweepError("no tinySA device found; pass --port to select a serial device")
+    if len(ports) > 1:
+        port_list = ", ".join(port.device for port in ports)
+        raise SweepError(f"multiple tinySA devices found ({port_list}); pass --port")
+    return ports[0].device
+
+
+def clear_buffer(usb: serial.Serial) -> None:
+    while usb.in_waiting:
+        usb.read_all()
+        time.sleep(0.01)
+
+
+def serial_query(usb: serial.Serial, command: str) -> str:
+    payload = command.encode()
+    usb.write(payload)
+    usb.read_until(payload + b"\n")
+    response = usb.read_until(PROMPT)
+    if not response.endswith(PROMPT):
+        raise SweepError(f"timed out waiting for prompt after {command.strip()!r}")
+    return response[: -len(PROMPT)].decode(errors="replace").strip()
+
+
+def serial_write(usb: serial.Serial, command: str) -> None:
+    payload = command.encode()
+    usb.write(payload)
+    response = usb.read_until(PROMPT)
+    if not response.endswith(PROMPT):
+        raise SweepError(f"timed out waiting for prompt after {command.strip()!r}")
+
+
+def setup_device(usb: serial.Serial, version: str, rbw: str) -> None:
+    commands = [
+        "abort on\r",
+        f"rbw {rbw}\r",
+        "attenuate auto\r",
+    ]
+    if is_ultra(version):
+        commands.extend(["lna off\r", "spur auto\r"])
+    else:
+        commands.append("spur on\r")
+
+    for command in commands:
+        logging.info("setup: %s", command.strip())
+        serial_write(usb, command)
+
+
+def sweep_timeout_seconds(start_hz: int, stop_hz: int, points: int, rbw: str) -> float:
+    """Use the same broad timeout heuristic as the GUI for one 20-point block."""
+    if rbw == "auto":
+        rbw_khz = (stop_hz - start_hz) * 7e-6
+    else:
+        try:
+            rbw_khz = float(rbw)
+        except ValueError:
+            return 10.0
+
+    rbw_khz = min(max(rbw_khz, 0.2), 850)
+    timeout = ((stop_hz - start_hz) / 20e3) / (rbw_khz**2) + points / 500
+    return max(timeout * 20 / points + 1, 1.0)
+
+
+def run_sweep(
+    usb: serial.Serial,
+    start_hz: int,
+    stop_hz: int,
+    points: int,
+    scale: int,
+    rbw: str,
+) -> list[float]:
+    command = f"scanraw {start_hz} {stop_hz} {points} 3\r"
+    usb.timeout = sweep_timeout_seconds(start_hz, stop_hz, points, rbw)
+
+    logging.info("sweep: %s", command.strip())
+    usb.write(command.encode())
+    header = usb.read_until(command.encode() + b"\n{")
+    if not header.endswith(command.encode() + b"\n{"):
+        raise SweepError("timed out waiting for scanraw data start")
+
+    readings = []
+    for _point in range(points):
+        block = usb.read(3)
+        if block == b"}":
+            raise SweepError("sweep stopped by tinySA screen touch or jog button")
+        readings.append(decode_sample(block, scale))
+
+    # Newer firmware can auto-repeat scanraw. Stop after the first sweep and
+    # drain back to the command prompt so the device is left in command mode.
+    usb.write(b"abort\r")
+    usb.read_until(PROMPT)
+    return readings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run one headless tinySA sweep and save frequency_hz,dbm CSV data."
+    )
+    parser.add_argument("--center", required=True, type=parse_frequency, help="center frequency in Hz")
+    parser.add_argument("--span", required=True, type=parse_frequency, help="sweep bandwidth/span in Hz")
+    parser.add_argument("--points", default=300, type=parse_points, help="number of sweep points (default: 300)")
+    parser.add_argument("--out", type=Path, help="CSV output path (default: timestamped CSV in sweep_files)")
+    parser.add_argument("--port", help="serial port override, e.g. /dev/ttyACM0 or COM3")
+    parser.add_argument("--rbw", default="auto", help="RBW in kHz or 'auto' (default: auto)")
+    parser.add_argument("--verbose", action="store_true", help="show setup and sweep progress")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(format="%(message)s", level=logging.INFO if args.verbose else logging.WARNING)
+
+    try:
+        start_hz, stop_hz = center_span_to_start_stop(args.center, args.span)
+        frequencies_hz = frequency_axis(start_hz, stop_hz, args.points)
+        output_path = args.out or default_output_path()
+        port = choose_port(args.port)
+
+        logging.info("opening %s at %s baud", port, BAUDRATE)
+        with serial.Serial(port, baudrate=BAUDRATE, timeout=2) as usb:
+            clear_buffer(usb)
+            version = serial_query(usb, "version\r")
+            scale = scale_for_version(version)
+            logging.info("device: %s", version)
+            setup_device(usb, version, args.rbw)
+            readings = run_sweep(usb, start_hz, stop_hz, args.points, scale, args.rbw)
+
+        write_csv(output_path, frequencies_hz, readings)
+        print(f"wrote {len(readings)} points to {output_path}")
+        return 0
+    except (OSError, serial.SerialException, SweepError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Hi, I’ve been experimenting with tinySA workflows where an LLM can inspect sweep data, so I put together two small scripts: one to run a headless sweep to CSV without starting the GUI, and one to plot/analyze the saved sweep data when needed.

Maybe similar functionality exists elsewhere, but adding a minimal version here seemed useful since it reuses the same scanraw behavior and CSV data can be inspected by other tools. I’m happy to adjust style, scope, naming, or functionality if you’d prefer a different direction.


## Summary
- Add a standalone tinySA sweep CLI that runs one scanraw sweep and writes frequency_hz/dbm CSV output
- Add a spectrum plotter CLI that plots sweep CSVs and prints trace summaries plus the top maxima per trace
- Add pandas and matplotlib requirements for the plotting script

## Notes
- The sweep CLI does not import QtTinySA.py, so it can run headlessly without starting the GUI
- If --out is omitted, sweep data is saved to a timestamped CSV in sweep_files/
- The plotter does not save by default; graph and peak CSV output are only written with --save
- The plotter supports both frequency_hz/dbm CSVs and older QtTinySA trace-pair CSV exports

## Testing
- python src/tinysa_sweep_cli.py --center 2400e6 --span 20e6 --points 401
- python src/spectrum_plotter.py sweep_files/<timestamp>_sweep.csv --no-show
- python src/spectrum_plotter.py sweep_files/<timestamp>_sweep.csv --save --no-show
- python3 -m py_compile src/spectrum_plotter.py src/tinysa_sweep_cli.py