### PR TITLE
Fix frequency range typing: apply on Enter, not every keystroke

### DIFF
--- a/src/modules/spectrum.ui
+++ b/src/modules/spectrum.ui
@@ -1419,6 +1419,9 @@ and Colours</string>
          <property name="frame">
           <bool>true</bool>
          </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
          <property name="correctionMode">
           <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
          </property>
@@ -1476,6 +1479,9 @@ and Colours</string>
          <property name="buttonSymbols">
           <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
          </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
          <property name="correctionMode">
           <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
          </property>
@@ -1526,6 +1532,9 @@ and Colours</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
          </property>
          <property name="correctionMode">
           <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
@@ -1855,6 +1864,9 @@ and Colours</string>
          </property>
          <property name="buttonSymbols">
           <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+         </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
          </property>
          <property name="correctionMode">
           <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>

--- a/src/tests/test_spectrum_ui.py
+++ b/src/tests/test_spectrum_ui.py
@@ -1,0 +1,56 @@
+"""
+Headless checks on the sweep frequency spin boxes declared in spectrum.ui.
+
+These parse the .ui XML directly, so no QApplication or display is needed.
+
+Run from the src directory so that the relative path resolves:
+    python -m pytest tests -q
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+
+UI_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "modules",
+    "spectrum.ui",
+)
+
+# All four are wired to valueChanged, which clamps the range and restarts the
+# sweep. With keyboard tracking on, that fires on every digit typed.
+FREQ_SPIN_BOXES = ("start_freq", "centre_freq", "stop_freq", "span_freq")
+
+
+@pytest.fixture(scope="module")
+def widgets():
+    root = ET.parse(UI_PATH).getroot()
+    return {
+        widget.get("name"): widget
+        for widget in root.iter("widget")
+        if widget.get("class") == "QDoubleSpinBox"
+    }
+
+
+def properties(widget):
+    return {prop.get("name"): prop for prop in widget.findall("property")}
+
+
+class TestFrequencySpinBoxes:
+    @pytest.mark.parametrize("name", FREQ_SPIN_BOXES)
+    def test_widget_is_present(self, widgets, name):
+        assert name in widgets
+
+    @pytest.mark.parametrize("name", FREQ_SPIN_BOXES)
+    def test_keyboard_tracking_is_off(self, widgets, name):
+        """Typing must not apply until Enter, focus loss, or a spin button."""
+        prop = properties(widgets[name]).get("keyboardTracking")
+        assert prop is not None, f"{name} has no keyboardTracking property"
+        assert prop.find("bool").text == "false"
+
+    @pytest.mark.parametrize("name", FREQ_SPIN_BOXES)
+    def test_still_displays_four_decimals(self, widgets, name):
+        # The 4-decimal display is what made partial input unreadable while
+        # tracking was on; keep it, since the fix defers the reformat instead.
+        assert properties(widgets[name])["decimals"].find("number").text == "4"


### PR DESCRIPTION
## Summary
- Turns off `keyboardTracking` on the start/centre/stop/span frequency spin boxes so typing no longer reformats to four decimals or restarts the sweep on every digit.
- `valueChanged` is unchanged, so the up/down arrows still apply immediately; Enter, focus loss, and the existing start>stop clamp still run on commit.
- Adds a small headless XML test that pins `keyboardTracking=false` on those four widgets.

Fixes https://github.com/g4ixt/QtTinySA/issues/140

## Test plan
- [ ] While scanning, type a new start frequency: the sweep must not change until Enter (or click away), then restart once with the new start.
- [ ] With scanning stopped, type a new stop frequency (e.g. 660 to 800): digits stay editable; the box must not jump to four decimal padding or snap to start until commit.
- [ ] Spin arrows still nudge frequency immediately.
- [ ] Centre and span typing behave the same way.
- [ ] Band preset dropdown still sets start/stop as today.
- [ ] Optional: from `src`, `python -m pytest tests/test_spectrum_ui.py -q`